### PR TITLE
fix/smoke test deployment protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,20 +126,25 @@ jobs:
           echo "deployed to $url"
 
       - name: Smoke-test the deployment
+        env:
+          VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set -euo pipefail
           url="${{ steps.deploy.outputs.url }}"
           fail() { echo "::error::$1"; exit 1; }
 
-          code=$(curl -sS -o /dev/null -w '%{http_code}' "$url/")
+          [ -n "${VERCEL_BYPASS:-}" ] || fail "VERCEL_AUTOMATION_BYPASS_SECRET is not set — enable Protection Bypass for Automation in Vercel and add the secret to the repo"
+          bypass=(-H "x-vercel-protection-bypass: $VERCEL_BYPASS")
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' "${bypass[@]}" "$url/")
           [ "$code" = "200" ] || fail "home page returned HTTP $code"
 
-          headers=$(curl -sSI "$url/")
+          headers=$(curl -sSI "${bypass[@]}" "$url/")
           for header in content-security-policy strict-transport-security x-content-type-options; do
             grep -iq "^$header:" <<< "$headers" || fail "$header missing — the vercel.json translation dropped it"
           done
 
-          code=$(curl -sS -o /dev/null -w '%{http_code}' "$url/about")
+          code=$(curl -sS -o /dev/null -w '%{http_code}' "${bypass[@]}" "$url/about")
           [ "$code" = "200" ] || fail "/about returned HTTP $code — cleanUrls did not survive"
 
           echo "ok: home and /about serve 200 with security headers intact"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ One-time setup:
 2. Turn off the Git integration's production deploys, or every push deploys twice (Vercel's ungated
    one fails anyway for lack of `dotnet`).
 3. Set `SITE_URL` in the Vercel environment if it differs from `site.yaml`'s `url`.
+4. Repository secret `VERCEL_AUTOMATION_BYPASS_SECRET` — generate it under **Settings → Deployment
+   Protection → Protection Bypass for Automation** and copy the value into a GitHub Actions secret of
+   the same name.
+
+> **Deployment Protection makes the deploy URL 302.** With it enabled, the unique `*.vercel.app`
+> deploy URL redirects unauthenticated requests to an SSO login, so the smoke test would see `302`
+> instead of `200`. The deploy job sends the `x-vercel-protection-bypass` header
+> (`VERCEL_AUTOMATION_BYPASS_SECRET`) so it can verify the live deployment without turning protection
+> off for humans.
 
 > **Do not hand-write `.vercel/output/config.json`.** `vercel build` translates `cleanUrls`,
 > `trailingSlash` and `headers` from `vercel.json` into Build Output API routes; that format supports

--- a/src/Yggdrasil.Content/Site.fs
+++ b/src/Yggdrasil.Content/Site.fs
@@ -206,11 +206,10 @@ module Site =
             try
                 parse (deserializer.Deserialize<SiteDto>(File.ReadAllText path))
             with ex ->
-                let rec detail (e: exn) =
-                    match e.InnerException with
-                    | null -> e.Message
-                    | inner -> e.Message + " → " + detail inner
-
+                let rec detail (ex: exn) =
+                    match ex.InnerException with
+                    | null -> ex.Message
+                    | inner -> ex.Message + " → " + detail inner
                 Error [ $"{path}: invalid YAML: {detail ex}" ]
 
     let absoluteUrl (config: SiteConfig) (path: string) =

--- a/src/Yggdrasil.Generate/Config.fs
+++ b/src/Yggdrasil.Generate/Config.fs
@@ -82,8 +82,8 @@ let resolve (argv: string array) (configuredUrl: string) =
             function
             | Ok _ -> []
             | Error e -> [ e ]
-
         Error(errorOf root @ errorOf baseUrl)
+
 let distDirectory (config: GeneratorConfig) =
     let dist = Path.GetFullPath(Path.Combine(config.ProjectRoot, "dist"))
     let root = Path.GetFullPath config.ProjectRoot


### PR DESCRIPTION
This pull request improves deployment security and documentation, and includes a minor code cleanup. The main focus is on supporting Vercel's Deployment Protection by ensuring the CI smoke test can authenticate using a repository secret, and updating the documentation to explain this requirement.

**Deployment security and CI improvements:**

* The CI workflow (`.github/workflows/ci.yml`) now supports Vercel's Deployment Protection by requiring the `VERCEL_AUTOMATION_BYPASS_SECRET` repository secret and sending the `x-vercel-protection-bypass` header during smoke tests. This ensures the smoke test can verify deployments even when SSO protection is enabled.

**Documentation updates:**

* The `README.md` has been updated to document the need for the `VERCEL_AUTOMATION_BYPASS_SECRET` repository secret, including instructions on how to generate and use it, and an explanation of why the bypass is necessary for automated tests.

**Code cleanup:**

* Minor variable renaming for clarity in exception handling in `Site.fs` (`ex` to `ex` in a recursive function).
* Removed a redundant line in error handling in `Config.fs` for improved code clarity.